### PR TITLE
Spoof user agent for NOAA link check

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,9 @@ sphinx:
   config:
     linkcheck_ignore: ["https://doi.org/*"] # don't run link checker on DOI links since they are immutable
     nb_execution_raise_on_error: true # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
+    linkcheck_request_headers:
+       'https://*.noaa.gov/':
+         User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: '%-d %B %Y'
     html_theme: sphinx_pythia_theme

--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ sphinx:
     linkcheck_ignore: ["https://doi.org/*"] # don't run link checker on DOI links since they are immutable
     nb_execution_raise_on_error: true # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
     linkcheck_request_headers:
-       'https://*.noaa.gov/':
+       'https://www.noaa.gov/':
          User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: '%-d %B %Y'


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
fixes #31 

Trying this out... it's the same workaround we used for Foundations in https://github.com/ProjectPythia/pythia-foundations/pull/262/